### PR TITLE
Update "sonar-scanner-cli" URL and version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -L https://github.com/rancher/rancher-compose/releases/download/v0.12.5
     && chmod +x /usr/local/bin/rancher-compose
 
 RUN wget \
-        "https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227.zip" \
+        "https://dl.bintray.com/sonarsource/SonarQube/org/sonarsource/scanner/cli/sonar-scanner-cli/3.3.0.1492/sonar-scanner-cli-3.3.0.1492.zip" \
         -O ./sonar-scanner.zip; \
     jar xf sonar-scanner.zip; \
     mv sonar-scanner-* sonar-scanner; \


### PR DESCRIPTION
#### Problem
 Bintray url-scheme does not fit anymore! Error building image. 

#### Solution
 Update Url -> image  builds again! 

#### Side effect
updated version of scanner cli.
3.2.0.1227 -> 3.3.0.1492

